### PR TITLE
Register scheduled live broadcasts from recent registered channels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+gem 'damerau-levenshtein'
 gem 'google-apis-calendar_v3'
 gem 'googleauth'
 gem 'nkf'

--- a/lib/slcc_calendar.rb
+++ b/lib/slcc_calendar.rb
@@ -115,12 +115,24 @@ module SLCCalendar
     end
 
     def events(past = 7, future = 120)
-      events = @service.list_events(@calendar_id,
-                                    max_results: 2500,
-                                    time_min: (Time.now - past * 24 * 60 * 60).iso8601,
-                                    time_max: (Time.now + future * 24 * 60 * 60).iso8601)
+      page_token = nil
+      items = []
 
-      events.items
+      time_min = (Time.now - ( past * 24 * 60 * 60 )).iso8601
+      time_max = (Time.now + ( future * 24 * 60 * 60 )).iso8601
+
+      begin
+        events = @service.list_events(@calendar_id,
+                                      max_results: 2500,
+                                      time_min: time_min,
+                                      time_max: time_max )
+        #events.items.each{|x| items << x }
+        items += events.items
+
+        page_token = events.next_page_token ? events.next_page_token : nil
+      end while !page_token.nil?
+
+      items
     end
 
     def create(schedule)

--- a/lib/slcc_schedule_collector.rb
+++ b/lib/slcc_schedule_collector.rb
@@ -45,6 +45,21 @@ module SLCCalendar
       @youtube_data_api_key = youtube_data_api_key
     end
 
+    def get_list_members(twitter_id, list_id)
+      client = Twitter::REST::Client.new do |config|
+        config.consumer_key = @twitter_consumer_key
+        config.consumer_secret = @twitter_consumer_secret
+        config.bearer_token = @twitter_bearer_token
+      end
+
+      members = []
+      client.list_members(twitter_id, list_id, {count: 5000, skip_status: true, include_entities: false}).each{|m|
+        members << {name: m.name.to_s, screen_name: m.screen_name.to_s, id: m.id.to_s}
+      }
+
+      return members
+    end
+
     def get_schedules(twitter_id, list_id, since_id: nil, include_ended: false)
       announces, latest_id = collect_announces(twitter_id, list_id, since_id: since_id)
       @latest_tweet_id = latest_id

--- a/lib/slcc_updater.rb
+++ b/lib/slcc_updater.rb
@@ -208,10 +208,6 @@ module SLCCalendar
         end
       end
 
-      #channels.sort_by{|_, v| v[:count]}.reverse.to_h.each{|k, v|
-      #  puts ("id: #{k}, channel_name: #{v[:name]}, count: #{v[:count]}")
-      #}
-
       twitter_list_members = []
 
       TWITTER_LISTS.each do |x|
@@ -222,10 +218,16 @@ module SLCCalendar
 
       channels.each{|k, v|
         name = v[:name].split(/Ch\.|ちゃんねる|Channel|channel/)[0].split(/[\/\-@＠‐]/)[0].gsub(' ', '').trunc(12)
-        puts "channel name: #{name}"
+
+        # if count is greater than 3, it will be checked.
+        if v[:count] > 3
+          channels[k][:need_check] = true
+          next
+        end
+
+        # if count is less than 3, check twitter lists.
         distances = []
         max_distance = 4
-
         twitter_list_members.each{|member|
           full_match = nil
           twn = member[:name].split(/[\/\-@＠‐]/)[0].gsub(/\(.+\)/,'').gsub(' ', '').trunc(16)
@@ -250,9 +252,16 @@ module SLCCalendar
             end
           end
         }
-        distances.sort{|a, b| a[1] <=> b[1]}.each{|x|
-          puts " twitter name: #{x[0]}, distance: #{x[1]}"
-        }
+
+        if distances.length > 0
+          channels[k][:need_check] = true
+        else
+          channels[k][:need_check] = false
+        end
+      }
+
+      channels.each{|id, v|
+        pp v
       }
 
     end

--- a/lib/slcc_updater.rb
+++ b/lib/slcc_updater.rb
@@ -192,7 +192,7 @@ module SLCCalendar
       )
 
       calendar = SLCCalendar::Calendar.new
-      current_events = calendar.events(10, 120)
+      current_events = calendar.events(14, 120)
       puts current_events.count
 
       channels = {}
@@ -282,7 +282,7 @@ module SLCCalendar
               if v.scheduled_start_time && (v.scheduled_start_time - Time.now) > 7 * 24 * 60 * 60
                 puts '  over +7 days to start. skip!'
                 next
-              elsif v.scheduled_start_time && (v.scheduled_start_time - Time.now) < 0
+              elsif v.scheduled_start_time && v.upcoming_stream? && (v.scheduled_start_time - Time.now) < 0
                 puts '  The schedule is the past. skip!'
                 next
               elsif v.scheduled_start_time.nil?

--- a/lib/slcc_updater.rb
+++ b/lib/slcc_updater.rb
@@ -229,21 +229,25 @@ module SLCCalendar
         twitter_list_members.each{|member|
           full_match = nil
           twn = member[:name].split(/[\/\-@＠‐]/)[0].gsub(/\(.+\)/,'').gsub(' ', '').trunc(16)
-          distance = DamerauLevenshtein.distance(name, twn)
-          allowed_distance = max_distance
-          if name.length - 2 <= max_distance
-            allowed_distance = name.length - 2
+          if twn.length <= name.length
+            full_match = twn if twn == name[0...twn.length]
+          else
+            full_match = twn if twn[0...name.length] == name
           end
 
-          if distance <= allowed_distance
-            distances << [twn, distance] if distance <= allowed_distance
+          if full_match
+            distances << [full_match, -1]
+            break
           else
-            if twn.length <= name.length
-              full_match = twn if twn == name[0...twn.length]
-            else
-              full_match = name if twn[0...name.length] == name
+            distance = DamerauLevenshtein.distance(name, twn)
+            allowed_distance = max_distance
+            if name.length - 2 <= max_distance
+              allowed_distance = name.length - 2
             end
-            distances << [full_match, -1] if full_match
+
+            if distance <= allowed_distance
+              distances << [twn, distance] if distance <= allowed_distance
+            end
           end
         }
         distances.sort{|a, b| a[1] <=> b[1]}.each{|x|

--- a/lib/slcc_updater.rb
+++ b/lib/slcc_updater.rb
@@ -306,7 +306,7 @@ module SLCCalendar
 
       videos.each{|v|
         sc = Schedule.new(video: v, tweet: nil)
-        $logger.info "CREATE: #{calendar.event_summary(calendar.gen_event(sc))}" # TBD
+        $logger.info "CREATE: #{calendar.event_summary(calendar.create(sc))}"
       }
     end
 

--- a/lib/slcc_youtube.rb
+++ b/lib/slcc_youtube.rb
@@ -116,7 +116,7 @@ module SLCCalendar
 
       playlist_items = api_get(
         resource: 'playlistItems',
-        options: { part: 'snippet', playlistId: playlist_id }
+        options: { part: 'snippet', maxResults: 50, playlistId: playlist_id }
       )
 
       return nil if playlist_items.nil? || playlist_items['items'].nil? || playlist_items['items'].length == 0
@@ -128,6 +128,17 @@ module SLCCalendar
       }
 
       get_videos(video_ids)
+    end
+
+    def get_playlist_id_by_channel_id(channel_id)
+      channel = api_get(
+        resource: 'channels',
+        options: {part: 'contentDetails', id: channel_id}
+      )
+
+      return nil if channel['items'].nil? || channel['items'].length == 0 || channel['items'][0]['contentDetails'].nil? || channel['items'][0]['contentDetails']['relatedPlaylists'].nil?
+
+      channel['items'][0]['contentDetails']['relatedPlaylists']['uploads']
     end
 
     private

--- a/lib/slcc_youtube.rb
+++ b/lib/slcc_youtube.rb
@@ -111,6 +111,25 @@ module SLCCalendar
       videos
     end
 
+    def get_playlist_videos(playlist_id)
+      video_ids = []
+
+      playlist_items = api_get(
+        resource: 'playlistItems',
+        options: { part: 'snippet', playlistId: playlist_id }
+      )
+
+      return nil if playlist_items.nil? || playlist_items['items'].nil? || playlist_items['items'].length == 0
+
+      playlist_items['items'].each{|v|
+        next if v['snippet'].nil?
+
+        video_ids << v['snippet']['resourceId']['videoId']
+      }
+
+      get_videos(video_ids)
+    end
+
     private
 
     def video_id_array_to_video_ids(video_id_array)


### PR DESCRIPTION
Current implementation only picks tweeted live broadcasts and register it.
This change registers upcoming live broadcasts based on the channel information of live broadcasts registered in the past.